### PR TITLE
Additional scan folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,14 @@ dir-assistant
 Running `dir-assistant` will scan all files recursively in your current directory. The most relevant files will 
 automatically be sent to the LLM when you enter a prompt.
 
+### Additional scan folders
+
+You can include files from folders outside your current directory:
+
+```shell
+dir-assistant start --additional-scan-folders "/path/to/folder1,/path/to/folder2"
+```
+
 ### Ignoring files
 
 You can ignore files when starting up so they will not be included in the assistant's context:

--- a/dir_assistant/assistant/index.py
+++ b/dir_assistant/assistant/index.py
@@ -60,11 +60,20 @@ def get_files_with_contents(directory, ignore_paths, cache_db):
     return files_with_contents
 
 
-def create_file_index(embed, ignore_paths, embed_chunk_size):
+def create_file_index(embed, ignore_paths, embed_chunk_size, additional_folders=[]):
     cache_db = get_file_path(INDEX_CACHE_PATH, INDEX_CACHE_FILENAME)
 
     print(f"{Fore.LIGHTBLACK_EX}Finding files to index...{Style.RESET_ALL}")
+    # Start with current directory
     files_with_contents = get_files_with_contents(".", ignore_paths, cache_db)
+    
+    # Add files from additional folders
+    for folder in additional_folders:
+        if os.path.exists(folder):
+            folder_files = get_files_with_contents(folder, ignore_paths, cache_db)
+            files_with_contents.extend(folder_files)
+        else:
+            print(f"{Fore.LIGHTBLACK_EX}Warning: Additional folder {folder} does not exist{Style.RESET_ALL}")
     chunks = []
     embeddings_list = []
     with SqliteDict(cache_db, autocommit=True) as cache:

--- a/dir_assistant/cli/start.py
+++ b/dir_assistant/cli/start.py
@@ -104,6 +104,9 @@ see readme for more information. Exiting..."""
         exit(1)
 
     ignore_paths = args.i__ignore if args.i__ignore else []
+    additional_folders = []
+    if args.additional_scan_folders:
+        additional_folders = [f.strip() for f in args.additional_scan_folders.split(",")]
     ignore_paths.extend(config_dict["GLOBAL_IGNORES"])
 
     # Initialize the embedding model
@@ -123,7 +126,7 @@ see readme for more information. Exiting..."""
 
     # Create the file index
     print(f"{Fore.LIGHTBLACK_EX}Creating file embeddings and index...{Style.RESET_ALL}")
-    index, chunks = create_file_index(embed, ignore_paths, embed_chunk_size)
+    index, chunks = create_file_index(embed, ignore_paths, embed_chunk_size, additional_folders)
 
     # Set up the system instructions
     system_instructions_full = f"{system_instructions}\n\nThe user will ask questions relating \

--- a/dir_assistant/main.py
+++ b/dir_assistant/main.py
@@ -28,6 +28,11 @@ def main():
         nargs="+",
         help="A list of space-separated filepaths to ignore.",
     )
+    parser.add_argument(
+        "--additional-scan-folders",
+        type=str,
+        help="Comma-separated list of additional folders to scan",
+    )
 
     mode_subparsers = parser.add_subparsers(
         dest="mode", help="Run dir-assistant in regular mode"


### PR DESCRIPTION
# Additional scan folders

You can include files from folders outside your current directory:

```shell
dir-assistant start --additional-scan-folders "/path/to/folder1,/path/to/folder2"
```