### PR TITLE
Fix path traversal vulnerability in GitAssistant

### DIFF
--- a/dir_assistant/assistant/git_assistant.py
+++ b/dir_assistant/assistant/git_assistant.py
@@ -120,6 +120,25 @@ if __name__ == "__main__":
             )
             output_lines = stream_output.split("\n")
             changed_filepath = output_lines[0].strip()
+
+            # Security: Validate the filepath to prevent path traversal attacks
+            if ".." in changed_filepath or os.path.isabs(changed_filepath):
+                if self.chat_mode:
+                    self.write_error_message(
+                        f"Error: Invalid file path '{changed_filepath}'. "
+                        "Path must be relative and within the project directory."
+                    )
+                return True  # Abort the operation
+
+            abs_path = os.path.abspath(changed_filepath)
+            if not abs_path.startswith(os.getcwd()):
+                if self.chat_mode:
+                    self.write_error_message(
+                        f"Error: Invalid file path '{changed_filepath}'. "
+                        "Attempted to write outside the project directory."
+                    )
+                return True  # Abort the operation
+
             file_content_lines = []
             if len(output_lines) > 1:
                 file_content_lines = output_lines[1:]

--- a/test/test_git_assistant.py
+++ b/test/test_git_assistant.py
@@ -1,0 +1,89 @@
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from dir_assistant.assistant.git_assistant import GitAssistant
+
+
+class TestGitAssistant(unittest.TestCase):
+    def setUp(self):
+        self.assistant = GitAssistant(
+            system_instructions="Test instructions",
+            embed=None,
+            index=None,
+            chunks=[],
+            context_file_ratio=0.5,
+            artifact_excludable_factor=0.5,
+            api_context_cache_ttl=3600,
+            rag_optimizer_weights={},
+            output_acceptance_retries=1,
+            use_cgrag=False,
+            print_cgrag=False,
+            commit_to_git=True,
+            verbose=False,
+            no_color=True,
+            chat_mode=True,
+            hide_thinking=True,
+            thinking_start_pattern="",
+            thinking_end_pattern="",
+        )
+        self.assistant.should_diff = True
+        self.assistant.git_apply_error = None
+
+    @patch("dir_assistant.assistant.git_assistant.prompt", return_value="y")
+    @patch("os.system")
+    @patch("os.makedirs")
+    @patch("builtins.open")
+    def test_file_traversal_attack_blocked(
+        self, mock_open, mock_makedirs, mock_system, mock_prompt
+    ):
+        # Simulate a malicious stream_output
+        malicious_output = "../../../etc/passwd\nmalicious content"
+        user_input = "test"
+
+        # Mock the write_error_message method to capture its output
+        self.assistant.write_error_message = MagicMock()
+
+        # Run the method
+        result = self.assistant.run_post_stream_processes(user_input, malicious_output)
+
+        # Assert that the file was not opened for writing
+        mock_open.assert_not_called()
+        # Assert that the error message was called with the expected message
+        self.assistant.write_error_message.assert_called_once()
+        self.assertIn(
+            "Invalid file path", self.assistant.write_error_message.call_args[0][0]
+        )
+        # Assert that the method returned True to abort the operation
+        self.assertTrue(result)
+
+    @patch("dir_assistant.assistant.git_assistant.prompt", return_value="y")
+    @patch("os.system")
+    @patch("os.makedirs")
+    @patch("builtins.open")
+    def test_absolute_path_attack_blocked(
+        self, mock_open, mock_makedirs, mock_system, mock_prompt
+    ):
+        # Simulate a malicious stream_output
+        malicious_output = "/root/.ssh/authorized_keys\nmalicious content"
+        user_input = "test"
+
+        # Mock the write_error_message method to capture its output
+        self.assistant.write_error_message = MagicMock()
+
+        # Run the method
+        result = self.assistant.run_post_stream_processes(user_input, malicious_output)
+
+        # Assert that the file was not opened for writing
+        mock_open.assert_not_called()
+        # Assert that the error message was called with the expected message
+        self.assistant.write_error_message.assert_called_once()
+        self.assertIn(
+            "Invalid file path", self.assistant.write_error_message.call_args[0][0]
+        )
+        # Assert that the method returned True to abort the operation
+        self.assertTrue(result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This commit addresses a critical security vulnerability where LLM-generated file paths were not being validated before being used to write to the filesystem. This could allow an attacker to write to arbitrary locations, potentially leading to remote code execution.

The fix implements robust validation for the `changed_filepath` in the `run_post_stream_processes` method of the `GitAssistant` class. The validation ensures that the path is relative, does not contain path traversal characters (`..`), and is within the current working directory.

A new test file, `test/test_git_assistant.py`, has been added with specific test cases to verify that path traversal and absolute path attacks are blocked.